### PR TITLE
fix: shorten release commit message (unblock publish)

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -11,6 +11,7 @@ module.exports = {
     }],
     ["@semantic-release/git", {
       "assets": ["CHANGELOG.md", "package.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]",
     }],
     '@semantic-release/github'
   ],


### PR DESCRIPTION
## Problem
semantic-release reached the `@semantic-release/git` prepare step but failed with `E2BIG: git commit -m chore(release): 1.0.0 [skip ci]` — the default commit message embeds the full release notes, which are huge here, exceeding the OS argument limit.

## Fix
Set the `@semantic-release/git` `message` to `chore(release): ${nextRelease.version} [skip ci]` (no embedded notes). Notes still go to CHANGELOG.md and the GitHub release.