### PR TITLE
docs: fix README (internal package, drop stale duplicate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,9 @@
-# OpenapiAutomatons
-[![CI/CD](https://github.com/openapi-automatons/openapi-automatons/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/openapi-automatons/openapi-automatons/actions/workflows/ci-cd.yml)
-[![codecov](https://codecov.io/gh/openapi-automatons/openapi-automatons/branch/main/graph/badge.svg)](https://codecov.io/gh/openapi-automatons/openapi-automatons)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![npm downloads](https://img.shields.io/npm/dt/openapi-automatons)](https://www.npmjs.com/package/openapi-automatons)
+# @automatons/parser
+[![CI/CD](https://github.com/openapi-automatons/parser/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/openapi-automatons/parser/actions/workflows/ci-cd.yml)
+[![npm downloads](https://img.shields.io/npm/dt/@automatons/parser)](https://www.npmjs.com/package/@automatons/parser)
 
-## What OpenapiAutomatons
-This library is a generator using openapi file.
+## What is @automatons/parser
+This is the OpenAPI parser used by openapi-automatons generators.
+Only use via [openapi-automatons](https://github.com/openapi-automatons/openapi-automatons).
 
-## What code can generate?
-| name | language | type | example |
-| ---- | -------- | ---- | ------- |
-| @automatons/typescript-axios | typescript | client | [example](https://github.com/openapi-automatons/openapi-automatons/tree/main/examples/typescript/clients/axios "example") |
-
-## Get Started
-1. Install library to your project
-```shell script
-yarn add -D openapi-automatons @automatons/typescript-axios
-```
-
-2. Create settings in your project root
-```json:automatons.json
-{
-  "openapi": "openapi.yml",
-  "automatons": [{
-    "automaton": "@automatons/typescript-axios",
-    "outDir": "src/clients"
-  }]
-}
-```
-
-3. Add generate command your package.json
-```json:package.json
-{
-  "scripts": {
-    "generate": "openapi-automatons"
-  }
-}
-```
-
-## Automatons.json
-| property |     | type | required | description |
-| -------- | --- | ---- | -------- | ----------- |
-| openapi | | string | true | This is openapi path. It can be relative or absolute. Also, there is no problem with the url format.|
-| automatons | | array | true | This is the property that contains the module. |
-| automatons | automaton | string | true | This is the module name. You can embed your own module. It is also possible to include it with a relative path. |
-| automatons | outDir | string | true | This is the output directory of module. |
+Since v1 this package is **ESM-only** and requires **Node.js >= 22**.


### PR DESCRIPTION
The README was a stale copy of the openapi-automatons usage doc referencing the old `@automatons/typescript-axios` name. Replace it with a minimal internal-package README that points to openapi-automatons and notes the ESM-only / Node >= 22 requirement.