### PR TITLE
feat: support anyOf, 3.1 type arrays/const, and the 3.2 server name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@automatons/tools": "^2.0.0",
+    "@automatons/tools": "^2.1.0",
     "change-case": "^5.4.4"
   },
   "devDependencies": {

--- a/src/converters/anyOf.ts
+++ b/src/converters/anyOf.ts
@@ -1,0 +1,9 @@
+import {OpenapiSchemaAnyOf} from '@automatons/tools';
+import {AnyOfSchema, Schema} from '../types';
+import {convertSchema} from './schema';
+
+export const convertAnyOf = (schema: OpenapiSchemaAnyOf, schemas: Schema[]): AnyOfSchema => ({
+  type: 'anyOf',
+  ...convertSchema(schema),
+  schemas,
+});

--- a/src/converters/normalize.test.ts
+++ b/src/converters/normalize.test.ts
@@ -1,0 +1,45 @@
+import {OpenapiSchema} from '@automatons/tools';
+import {normalizeSchema} from './normalize';
+
+const normalize = (schema: unknown) => normalizeSchema(schema as OpenapiSchema) as Record<string, unknown>;
+
+it('converts type [X, null] to nullable single type', () => {
+  expect(normalize({type: ['string', 'null']})).toEqual({type: 'string', nullable: true});
+});
+
+it('preserves sibling keywords on nullable single type', () => {
+  expect(normalize({type: ['string', 'null'], format: 'date'}))
+    .toEqual({type: 'string', format: 'date', nullable: true});
+});
+
+it('converts a multi type to anyOf', () => {
+  expect(normalize({type: ['string', 'number']}))
+    .toEqual({anyOf: [{type: 'string'}, {type: 'number'}], nullable: false});
+});
+
+it('converts a multi type with null to anyOf + nullable', () => {
+  expect(normalize({type: ['string', 'number', 'null']}))
+    .toEqual({anyOf: [{type: 'string'}, {type: 'number'}], nullable: true});
+});
+
+it('converts const string to a single-value enum', () => {
+  expect(normalize({const: 'active'})).toEqual({type: 'string', enum: ['active']});
+});
+
+it('converts const number to a single-value enum', () => {
+  expect(normalize({const: 5})).toEqual({type: 'number', enum: [5]});
+});
+
+it('converts const boolean to a single-value enum', () => {
+  expect(normalize({const: true})).toEqual({type: 'boolean', enum: [true]});
+});
+
+it('keeps an explicit type alongside const', () => {
+  expect(normalize({type: 'string', const: 'x'})).toEqual({type: 'string', enum: ['x']});
+});
+
+it('passes a normal schema through unchanged and is idempotent', () => {
+  const schema = {type: 'string', format: 'date'};
+  expect(normalize(schema)).toEqual(schema);
+  expect(normalize(normalize(schema))).toEqual(schema);
+});

--- a/src/converters/normalize.ts
+++ b/src/converters/normalize.ts
@@ -1,0 +1,43 @@
+import {OpenapiSchema} from '@automatons/tools';
+
+const inferType = (value: unknown): string =>
+  typeof value === 'number' ? 'number' : typeof value === 'boolean' ? 'boolean' : 'string';
+
+/**
+ * Normalize OpenAPI 3.1 (JSON Schema 2020-12) schema constructs into the 3.0-style
+ * model the extractors understand. Idempotent.
+ *
+ * - `type: ["X", "null"]`      -> `{type: "X", nullable: true}`
+ * - `type: ["X", "Y"]`         -> `{anyOf: [{type: "X"}, {type: "Y"}]}`
+ * - `type: ["X", "Y", "null"]` -> `{anyOf: [...], nullable: true}`
+ * - `const: V`                 -> `{enum: [V]}` (type inferred from V when absent)
+ *
+ * Out of scope: a sole `type: ["null"]` / `const: null` (returned unchanged), and other
+ * 2020-12 keywords (prefixItems, patternProperties, ...).
+ */
+export const normalizeSchema = (raw: OpenapiSchema): OpenapiSchema => {
+  const loose = raw as Record<string, unknown>;
+
+  if (Array.isArray(loose.type)) {
+    const types = loose.type as string[];
+    const hasNull = types.includes('null');
+    const nonNull = types.filter((type) => type !== 'null');
+    if (nonNull.length === 0) return raw;
+    const nullable = hasNull || Boolean(loose.nullable);
+    const rest: Record<string, unknown> = {...loose};
+    delete rest.type;
+    if (nonNull.length === 1) {
+      return {...rest, type: nonNull[0], nullable} as unknown as OpenapiSchema;
+    }
+    return {...rest, anyOf: nonNull.map((type) => ({type})), nullable} as unknown as OpenapiSchema;
+  }
+
+  if (loose.const !== undefined && loose.const !== null) {
+    const value = loose.const;
+    const rest: Record<string, unknown> = {...loose};
+    delete rest.const;
+    return {...rest, type: (loose.type as string | undefined) ?? inferType(value), enum: [value]} as unknown as OpenapiSchema;
+  }
+
+  return raw;
+};

--- a/src/converters/server.test.ts
+++ b/src/converters/server.test.ts
@@ -1,0 +1,22 @@
+import {pascalCase} from 'change-case';
+import {convertServer} from './server';
+
+it('prefers the standard 3.2 name', () => {
+  expect(convertServer({name: 'Main', 'x-name': 'Other', url: 'http://x'}).name).toBe('Main');
+});
+
+it('falls back to x-name when name is absent', () => {
+  expect(convertServer({'x-name': 'My Server', url: 'http://x'}).name).toBe('MyServer');
+});
+
+it('falls back to the url when neither name nor x-name is set', () => {
+  const url = 'http://api.example.com/v1';
+  expect(convertServer({url}).name).toBe(pascalCase(url));
+});
+
+it('converts server variables', () => {
+  expect(convertServer({
+    url: 'http://x',
+    variables: {port: {default: '8080', enum: ['8080', '9090']}},
+  }).values).toEqual([{name: 'port', defaultValue: '8080', enums: ['8080', '9090']}]);
+});

--- a/src/converters/server.ts
+++ b/src/converters/server.ts
@@ -4,7 +4,7 @@ import {convertMap} from './map';
 import {pascalCase} from 'change-case';
 
 export const convertServer = (schema: OpenapiServer): Server => ({
-  name: pascalCase(schema['x-name'] ?? schema.url),
+  name: pascalCase(schema.name ?? schema['x-name'] ?? schema.url),
   url: schema.url,
   values: convertMap(schema.variables).map(({key, schema}) =>
     ({name: key, defaultValue: schema.default, enums: schema.enum})),

--- a/src/extractors/model/anyOf.ts
+++ b/src/extractors/model/anyOf.ts
@@ -1,0 +1,9 @@
+import {convertModel} from '../../converters/model';
+import {convertAnyOf} from '../../converters/anyOf';
+import {extractOfModel} from './of';
+import {AutomatonContext, OpenapiSchemaAnyOf} from '@automatons/tools';
+
+export const extractAnyOfModel = async (title: string, schema: OpenapiSchemaAnyOf, context: AutomatonContext) => {
+  const {models, schemas, imports} = await extractOfModel(title, schema.anyOf, context);
+  return {model: convertModel(title, convertAnyOf(schema, schemas), imports), insides: models};
+};

--- a/src/extractors/model/index.ts
+++ b/src/extractors/model/index.ts
@@ -5,6 +5,7 @@ import {
   isSchemaBoolean,
   isSchemaInteger,
   isSchemaNumber,
+  isSchemaAnyOf,
   isSchemaObject,
   isSchemaOneOf,
   isSchemaRef,
@@ -19,11 +20,14 @@ import {extractAllOfModel} from './allOf';
 import {extractArrayModel} from './array';
 import {extractObjectModel} from './object';
 import {extractOneOfModel} from './oneOf';
+import {extractAnyOfModel} from './anyOf';
 import {extractRefModel} from './ref';
 import {ExtractModel} from './type';
+import {normalizeSchema} from '../../converters/normalize';
 
 export const extractModel =
-  async (title: string, schema: OpenapiSchema, context: AutomatonContext): Promise<ExtractModel> => {
+  async (title: string, raw: OpenapiSchema, context: AutomatonContext): Promise<ExtractModel> => {
+    const schema = normalizeSchema(raw);
     if (isSchemaString(schema)) {
       return {model: convertModel(title, convertString(schema)), insides: []};
     } else if (isSchemaNumber(schema) || isSchemaInteger(schema)) {
@@ -38,6 +42,8 @@ export const extractModel =
       return extractAllOfModel(title, schema, context);
     } else if (isSchemaOneOf(schema)) {
       return extractOneOfModel(title, schema, context);
+    } else if (isSchemaAnyOf(schema)) {
+      return extractAnyOfModel(title, schema, context);
     } else if (isSchemaRef(schema)) {
       return extractRefModel(title, schema, context);
     }

--- a/src/extractors/schema/anyOf.ts
+++ b/src/extractors/schema/anyOf.ts
@@ -1,0 +1,14 @@
+import {AutomatonContext, OpenapiSchemaAnyOf} from '@automatons/tools';
+import {convertSchemaModel} from '../../converters/schemaModel';
+import {extractModel} from '../model';
+import {convertModel} from '../../converters/model';
+
+export const extractAnyOfSchema = async (title: string, schema: OpenapiSchemaAnyOf, context: AutomatonContext) => {
+  const modelSchema = convertSchemaModel(title, schema);
+  const {model, insides} = await extractModel(title, schema, context);
+  return {
+    schema: modelSchema,
+    models: [model, ...insides],
+    imports: [convertModel(title, modelSchema)],
+  };
+};

--- a/src/extractors/schema/index.ts
+++ b/src/extractors/schema/index.ts
@@ -4,6 +4,7 @@ import {
   isSchemaArray, isSchemaBoolean,
   isSchemaInteger,
   isSchemaNumber,
+  isSchemaAnyOf,
   isSchemaObject,
   isSchemaOneOf,
   isSchemaRef,
@@ -16,14 +17,17 @@ import {extractArraySchema} from './array';
 import {extractObjectSchema} from './object';
 import {extractAllOfSchema} from './allOf';
 import {extractOneOfSchema} from './oneOf';
+import {extractAnyOfSchema} from './anyOf';
 import {extractRefSchema} from './ref';
 import {extractStringSchema} from './string';
 import {extractBooleanSchema} from './boolean';
+import {normalizeSchema} from '../../converters/normalize';
 
 export type ExtractSchemaResult = { schema: Schema, models: Model[], imports?: Model[] };
 
-export const extractSchema = async (title: string, schema: OpenapiSchema,
+export const extractSchema = async (title: string, raw: OpenapiSchema,
   context: AutomatonContext): Promise<ExtractSchemaResult> => {
+  const schema = normalizeSchema(raw);
   if (isSchemaString(schema)) {
     return extractStringSchema(title, schema);
   } else if (isSchemaNumber(schema) || isSchemaInteger(schema)) {
@@ -38,6 +42,8 @@ export const extractSchema = async (title: string, schema: OpenapiSchema,
     return extractAllOfSchema(title, schema, context);
   } else if (isSchemaOneOf(schema)) {
     return extractOneOfSchema(title, schema, context);
+  } else if (isSchemaAnyOf(schema)) {
+    return extractAnyOfSchema(title, schema, context);
   } else if (isSchemaRef(schema)) {
     return extractRefSchema(title, schema);
   }

--- a/src/parsers/model.test.ts
+++ b/src/parsers/model.test.ts
@@ -209,6 +209,22 @@ describe('model parser', () => {
     ['oneOf', '$ref', 'oneOf', ['oneOf']],
     ['oneOf', '$ref', '$ref', ['oneOf']],
 
+    ['anyOf', undefined, undefined, ['anyOf']],
+    ['anyOf', 'string', undefined, ['anyOf']],
+    ['anyOf', 'number', undefined, ['anyOf']],
+    ['anyOf', 'integer', undefined, ['anyOf']],
+    ['anyOf', 'array', undefined, ['anyOf']],
+    ['anyOf', 'object', undefined, ['anyOf', 'object']],
+    ['anyOf', 'allOf', undefined, ['anyOf', 'allOf']],
+    ['anyOf', 'oneOf', undefined, ['anyOf', 'oneOf']],
+    ['anyOf', 'anyOf', undefined, ['anyOf', 'anyOf']],
+    ['anyOf', '$ref', 'string', ['anyOf']],
+    ['anyOf', '$ref', 'anyOf', ['anyOf']],
+    ['array', 'anyOf', undefined, ['array', 'anyOf']],
+    ['object', 'anyOf', undefined, ['object', 'anyOf']],
+    ['allOf', 'anyOf', undefined, ['allOf', 'anyOf']],
+    ['oneOf', 'anyOf', undefined, ['oneOf', 'anyOf']],
+
     ['$ref', undefined, undefined, ['model']],
     ['$ref', 'string', undefined, ['model']],
     ['$ref', 'number', undefined, ['model']],
@@ -223,9 +239,9 @@ describe('model parser', () => {
       createSchema(type, children ?
         createSchema(children) : undefined, children) : undefined, type));
     const models = await parseModel({openapi, settings: {path: './', openapiPath: './', outDir: './'}});
-    expect(models.map(({title}) => title)).toHaveLength(8 + names.length);
+    expect(models.map(({title}) => title)).toHaveLength(9 + names.length);
     expect(models.map(({schema: {type}}) => type))
-      .toEqual(['string', 'number', 'number', 'array', 'object', 'allOf', 'oneOf', 'model', ...names]);
+      .toEqual(['string', 'number', 'number', 'array', 'object', 'allOf', 'oneOf', 'anyOf', 'model', ...names]);
   });
 });
 const createSchema = (type: string, children?: OpenapiSchema, ref: string = 'string'): OpenapiSchema => {
@@ -262,6 +278,10 @@ const createSchema = (type: string, children?: OpenapiSchema, ref: string = 'str
     return {
       oneOf: children ? [children] : [],
     };
+  case 'anyOf':
+    return {
+      anyOf: children ? [children] : [],
+    };
   case '$ref':
     return {
       '$ref': `#/components/schemas/${ref}`,
@@ -286,6 +306,7 @@ const createOpenapi = (schema: OpenapiSchema): Openapi => ({
       object: {type: 'object'},
       allOf: {allOf: []},
       oneOf: {oneOf: []},
+      anyOf: {anyOf: []},
       $ref: {$ref: '#/components/schemas/object'},
       Schema: schema,
     },

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -7,6 +7,7 @@ export type Schema =
   | ObjectSchema
   | AllOfSchema
   | OneOfSchema
+  | AnyOfSchema
   | ModelSchema;
 
 export interface Model {
@@ -99,6 +100,12 @@ export interface AllOfSchema extends SchemaCommon {
 
 export interface OneOfSchema extends SchemaCommon {
   type: 'oneOf';
+  examples?: Example[];
+  schemas: Schema[];
+}
+
+export interface AnyOfSchema extends SchemaCommon {
+  type: 'anyOf';
   examples?: Example[];
   schemas: Schema[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@automatons/tools@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.0.1.tgz#1de28b8f3b925319d317515034e0530adba19a35"
-  integrity sha512-l7eUj0OA/p1z7xkpf7kwOGGRQBl2aqVUzXht3C85T1DDYHhXDpUz9v+1w5ckdO37nN4EBIQhAyjpOQ9i30ahzg==
+"@automatons/tools@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.1.0.tgz#b8bb2f4495b011d1aacd4cd094df506cebde6dc1"
+  integrity sha512-l7Vu9qFqz8qG7lyBw8BweEIJtZAnKGHir/Og+2IVKmBoXtu0y36V3UxLGUsBf0pgiin4ymMeoPNksO38cXBVOw==
   dependencies:
     js-yaml "^4.1.0"
 


### PR DESCRIPTION
Adds anyOf schema extraction (alongside oneOf), a normalization layer mapping 3.1 `type` arrays to nullable/anyOf and `const` to a single-value enum, and reads the standard 3.2 server `name` (falling back to `x-name`, then `url`). Bumps `@automatons/tools` to `^2.1.0`.