### PR TITLE
feat: extract OpenAPI 3.2 query/additionalOperations and querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@automatons/tools": "^2.1.0",
+    "@automatons/tools": "^2.2.0",
     "change-case": "^5.4.4"
   },
   "devDependencies": {

--- a/src/extractors/path/index.ts
+++ b/src/extractors/path/index.ts
@@ -11,9 +11,12 @@ export const extractPath =
     const _schema = isRef(schema) ?
       {...await referenceSchema(schema, {openapi, settings}), ...omitCopy(schema, '$ref')} :
       schema;
-    return Promise.all(HTTP_METHODS
+    const fixed = HTTP_METHODS
       .map<{ method: Method, operation: OpenapiPath | undefined }>((method) => ({method, operation: _schema[method]}))
       .filter<{ method: Method, operation: OpenapiPathOperation }>(
         (operation): operation is { method: Method, operation: OpenapiPathOperation } => !!operation.operation)
-      .map(({method, operation}) => extractMethod(path, method, operation, _schema, {openapi, settings})));
+      .map(({method, operation}) => extractMethod(path, method, operation, _schema, {openapi, settings}));
+    const additional = Object.entries(_schema.additionalOperations ?? {})
+      .map(([method, operation]) => extractMethod(path, method.toLowerCase(), operation, _schema, {openapi, settings}));
+    return Promise.all([...fixed, ...additional]);
   };

--- a/src/extractors/path/method.ts
+++ b/src/extractors/path/method.ts
@@ -1,4 +1,4 @@
-import {AutomatonContext, Method, OpenapiParameter, OpenapiPath, OpenapiPathOperation} from '@automatons/tools';
+import {AutomatonContext, OpenapiParameter, OpenapiPath, OpenapiPathOperation} from '@automatons/tools';
 import {camelCase} from 'change-case';
 import {convertServer} from '../../converters/server';
 import {
@@ -35,6 +35,7 @@ const mergeParameter =
       queries: _queries,
       headers: _headers,
       cookies: _cookies,
+      querystring: _querystring,
       models: _models,
       imports: _imports,
     } =
@@ -43,6 +44,7 @@ const mergeParameter =
     params.queries.push(..._queries);
     params.headers.push(..._headers);
     params.cookies.push(..._cookies);
+    if (_querystring) params.querystring = _querystring;
     mergeModels(models, {models: _models, imports: _imports});
   };
 
@@ -56,6 +58,7 @@ type Params = {
   queries: QueryParameter[];
   headers: HeaderParameter[];
   cookies: CookieParameter[];
+  querystring?: Schema;
 };
 
 type Data = {
@@ -66,7 +69,7 @@ type Data = {
   schema?: Schema;
 };
 
-export const extractMethod = async (path: string, method: Method, operation: OpenapiPathOperation, schema: OpenapiPath,
+export const extractMethod = async (path: string, method: string, operation: OpenapiPathOperation, schema: OpenapiPath,
   {openapi, settings}: AutomatonContext): Promise<PathReturn> => {
   const models: Models = {
     models: [],
@@ -110,7 +113,7 @@ export const extractMethod = async (path: string, method: Method, operation: Ope
   return convertPath(path, method, operation, data, models);
 };
 
-const convertPath = (path: string, method: Method, operation: OpenapiPathOperation,
+const convertPath = (path: string, method: string, operation: OpenapiPathOperation,
   {params, servers, securities, forms, schema}: Data, models: Models): PathReturn => ({
   tags: operation.tags && operation.tags.length ? operation.tags : ['default'],
   path: {
@@ -122,6 +125,7 @@ const convertPath = (path: string, method: Method, operation: OpenapiPathOperati
     queries: params.queries.sort(requiredCompare),
     headers: params.headers.sort(requiredCompare),
     cookies: params.cookies.sort(requiredCompare),
+    ...(params.querystring ? {querystring: params.querystring} : {}),
     ...(securities ? {securities} : {}),
     ...(forms ? {forms} : {}),
     ...(schema ? {schema} : {}),

--- a/src/extractors/path/parameter.ts
+++ b/src/extractors/path/parameter.ts
@@ -4,6 +4,7 @@ import {
   isHeaderParam,
   isPathParam,
   isQueryParam,
+  isQueryStringParam,
   OpenapiParameter,
   referenceSchema,
 } from '@automatons/tools';
@@ -71,6 +72,8 @@ export const extractParameter =
             models,
             imports,
           };
+        } else if (isQueryStringParam(_param)) {
+          return {querystring: schema, models, imports};
         }
         return;
       })
@@ -82,6 +85,7 @@ export const extractParameter =
           queries: current.query ? [...previous.queries, current.query] : previous.queries,
           headers: current.header ? [...previous.headers, current.header] : previous.headers,
           cookies: current.cookie ? [...previous.cookies, current.cookie] : previous.cookies,
+          querystring: current.querystring ?? previous.querystring,
           models: [...previous.models, ...current.models],
           imports: [...previous.imports, ...current.imports ?? []],
         }) :

--- a/src/extractors/path/response.ts
+++ b/src/extractors/path/response.ts
@@ -1,4 +1,4 @@
-import {Method, OpenapiMap, OpenapiPathResponse, OpenapiReference, referenceSchema} from '@automatons/tools';
+import {OpenapiMap, OpenapiPathResponse, OpenapiReference, referenceSchema} from '@automatons/tools';
 import {extractSchema, ExtractSchemaResult} from '../schema';
 import {extractMediaType} from './mediaType';
 import {extractStatus} from './status';
@@ -6,7 +6,7 @@ import {PathContext} from './type';
 
 export const extractResponse =
   async (schema: OpenapiMap<OpenapiPathResponse | OpenapiReference>,
-    method: Method,
+    method: string,
     context: PathContext): Promise<ExtractSchemaResult | void> => {
     const status = extractStatus(schema);
     const response = await referenceSchema(schema[status]!, context);

--- a/src/extractors/path/type.ts
+++ b/src/extractors/path/type.ts
@@ -1,5 +1,5 @@
 import {AutomatonContext} from '@automatons/tools';
-import {CookieParameter, HeaderParameter, Model, Path, PathParameter, QueryParameter} from '../../types';
+import {CookieParameter, HeaderParameter, Model, Path, PathParameter, QueryParameter, Schema} from '../../types';
 
 export type PathContext = { path: string } & AutomatonContext;
 export type ParameterResult = {
@@ -7,6 +7,7 @@ export type ParameterResult = {
   queries: QueryParameter[],
   headers: HeaderParameter[],
   cookies: CookieParameter[],
+  querystring?: Schema,
   models: Model[],
   imports: Model[]
 };

--- a/src/parsers/api.test.ts
+++ b/src/parsers/api.test.ts
@@ -35,6 +35,62 @@ describe('api parser', () => {
       ],
     }]);
   });
+
+  it('should parse the 3.2 query method and additionalOperations', async () => {
+    const openapi: Openapi = {
+      openapi: '3.2.0',
+      info: {title: 'test', version: '0.0.1'},
+      paths: {
+        tests: {
+          query: {
+            operationId: 'queryTests',
+            requestBody: {content: {'application/json': {schema: {type: 'object'}}}},
+            responses: {200: {description: 'ok', content: {'application/json': {schema: {type: 'string'}}}}},
+          },
+          additionalOperations: {
+            PURGE: {operationId: 'purgeTests', responses: {200: {description: 'ok'}}},
+          },
+        },
+      },
+      components: {},
+    };
+    const {apis} = await parseApi({openapi, settings: {path: './', openapiPath: './', outDir: './'}});
+    const paths = apis[0]!.paths;
+    expect(paths.map((path) => path.method).sort()).toEqual(['purge', 'query']);
+    const query = paths.find((path) => path.method === 'query')!;
+    expect('forms' in query && (query.forms?.length ?? 0) > 0).toBe(true);
+    const purge = paths.find((path) => path.method === 'purge')!;
+    expect('forms' in purge).toBe(false);
+  });
+
+  it('should parse a 3.2 querystring parameter', async () => {
+    const openapi: Openapi = {
+      openapi: '3.2.0',
+      info: {title: 'test', version: '0.0.1'},
+      paths: {
+        tests: {
+          get: {
+            operationId: 'searchTests',
+            parameters: [{
+              in: 'querystring',
+              name: '',
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {type: 'object', properties: {q: {type: 'string'}}},
+                },
+              },
+            }],
+            responses: {200: {description: 'ok', content: {'application/json': {schema: {type: 'string'}}}}},
+          },
+        },
+      },
+      components: {},
+    };
+    const {apis} = await parseApi({openapi, settings: {path: './', openapiPath: './', outDir: './'}});
+    const path = apis[0]!.paths[0]!;
+    expect(path.querystring).toBeDefined();
+    expect(path.querystring?.type).toBe('model');
+  });
 });
 
 const createOpenapi = (): Openapi => ({

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -14,22 +14,23 @@ export type ReceiveMethod = 'get' | 'head' | 'delete' | 'options' | 'trace';
 
 export type ReceivePath = {
   name: string;
-  method: ReceiveMethod;
+  method: string;
   path: string;
   servers: Server[];
   parameters?: PathParameter[];
   queries?: QueryParameter[];
   headers?: HeaderParameter[];
   cookies?: CookieParameter[];
+  querystring?: Schema;
   schema?: Schema;
   securities?: Security[];
 }
 
-export type AffectMethod = 'post' | 'put' | 'patch';
+export type AffectMethod = 'post' | 'put' | 'patch' | 'query';
 
 export type AffectPath = {
   name: string;
-  method: AffectMethod;
+  method: string;
   path: string;
   servers: Server[];
   forms?: Form[];
@@ -37,6 +38,7 @@ export type AffectPath = {
   queries?: QueryParameter[];
   headers?: HeaderParameter[];
   cookies?: CookieParameter[];
+  querystring?: Schema;
   schema?: Schema;
   securities?: Security[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,12 +43,12 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@automatons/tools@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.1.0.tgz#b8bb2f4495b011d1aacd4cd094df506cebde6dc1"
-  integrity sha512-l7Vu9qFqz8qG7lyBw8BweEIJtZAnKGHir/Og+2IVKmBoXtu0y36V3UxLGUsBf0pgiin4ymMeoPNksO38cXBVOw==
+"@automatons/tools@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@automatons/tools/-/tools-2.2.0.tgz#8aa60b9ca53040e0f1c02659d5c23e75603f6be0"
+  integrity sha512-JeehWbzyK1Efrz3YlJCXlKxOQQzjFriVN1WSuO3D6mM71coWESoJ4EJWyP8BA01mdJpvQ/YoZe/Os7A4K2Gejg==
   dependencies:
-    js-yaml "^4.1.0"
+    js-yaml "^4.2.0"
 
 "@babel/code-frame@^7.0.0":
   version "7.16.0"
@@ -3468,6 +3468,13 @@ js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Iterates the 3.2 `query` method + `additionalOperations` (arbitrary verbs; `Path.method` broadened to string) and extracts the `querystring` parameter into the path. Bumps `@automatons/tools` to `^2.2.0`.